### PR TITLE
suspend-on-cover-close: Switch to using (da)sh

### DIFF
--- a/pn_tweak_suspend_on_cover_close/data/pinenote_sleep_on_cover_close.sh
+++ b/pn_tweak_suspend_on_cover_close/data/pinenote_sleep_on_cover_close.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 echo "PineNote: Waiting for cover-close events..."
 event_close='*type 5 (EV_SW), code 16 (?), value 1'
 


### PR DESCRIPTION
There's no need to bring in the full weight of ``bash``, while ``sh`` (``dash`` on Debian) is sufficient.