### PR TITLE
remove U_BOOT_ROOT from u-boot-pinenote.conf

### DIFF
--- a/pn_basic_support/u-boot-default/u-boot-pinenote.conf
+++ b/pn_basic_support/u-boot-default/u-boot-pinenote.conf
@@ -7,7 +7,6 @@
 #U_BOOT_ENTRIES="all"
 #U_BOOT_MENU_LABEL="Debian GNU/Linux"
 U_BOOT_PARAMETERS="ignore_loglevel rw rootwait earlycon console=tty0 console=ttyS2,1500000n8 fw_devlink=off quiet loglevel=3 systemd.show_status=auto rd.udev.log_level=3 splash plymouth.ignore-serial-consoles vt.global_cursor_default=0"
-U_BOOT_ROOT="root=/dev/mmcblk0p5"
 U_BOOT_TIMEOUT="10"
 # Needed because the U-Boot (2017.9) that came with the device doesn't recognize the PineNote as such:
 U_BOOT_FDT="rockchip/rk3566-pinenote-v1.2.dtb"


### PR DESCRIPTION
When there's no U_BOOT_ROOT, u-boot-update will try to take it from fstab or kernel arguments (/proc/cmdline).

Should fix PNDeb/pinenote-debian-image#122, but will probably break builds.